### PR TITLE
Setup Github Action for Java 8 - 15

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -1,0 +1,23 @@
+name: Build & Check
+
+on: [push, pull_request]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    name: JDK ${{ matrix.jdk }}
+    strategy:
+      fail-fast: false
+      matrix:
+        jdk: [ '8', '11', '15' ] # todo: Update to Gradle 7 to be able to support newer Java versions
+        #os: [ubuntu-latest, windows-latest, macOS-latest]
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up JDK ${{ matrix.jdk }}
+      uses: actions/setup-java@v1
+      with:
+        java-version: ${{ matrix.jdk }}
+
+    - name: build & check
+      run: ./gradlew build check

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,11 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-5.0-bin.zip
+
+## Gradle 6.9 supports Java 8 - 15
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.9-bin.zip
+
+## Gradle 7.* supports Java 8 - latest
+#distributionUrl=https\://services.gradle.org/distributions/gradle-7.3.1-bin.zip
+
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
This is a step toward supporting newer versions of Java. To be able to support JDK 17 Gradle will need updating again but that will introduce further changes. This PR has minimal impact and ensure that the project can build on various Java versions.